### PR TITLE
make .gitignore not to upload unneccesary files to Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# -----------
+# source https://github.com/github/gitignore
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# --------
+# source https://gist.github.com/JonathanGawrych/32afe529fd519a7312df
+
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# Maven
+log/
+target/


### PR DESCRIPTION
Your app is very awesome！！

## Overview
.DS_Store file is now uploaded to your repo.
But the file is not necessary for your app.

Then, if you make ``.gitignore`` , you can able to manage which file you want to upload to github.
In this PR, I made the ``.gitignore`` file.

## What is .DS_Store
The file is made automatically when you make files.
Please refer https://applica.info/dsstore 

## .gitignore template
.gitignore template is presented by Github at this repo ( https://github.com/github/gitignore )
